### PR TITLE
fix: Corrected error with dictionary keys

### DIFF
--- a/app/server/commands/discord_commands.py
+++ b/app/server/commands/discord_commands.py
@@ -17,7 +17,7 @@ class Commands(ABC):
         self.subject_service = SubjectService()
 
     @abstractmethod
-    def execute(self, *args, **kwargs):
+    def execute(self):
         raise NotImplementedError("Subclasses must implement this method")
 
     @abstractmethod

--- a/app/server/commands/management_command.py
+++ b/app/server/commands/management_command.py
@@ -26,7 +26,5 @@ class CreateCommand(Commands):
     def get_help(self):
         return {
             "brief": "Create a new entity",
-            "help": "This command allows you to create a new entity. You can use it as follows:\n"
-                    "!create subject <name> <description> - Create a new subject\n"
-                    "!create topic <name> <description> <subject_id> - Create a new topic"
+            "help": "This command allows you to create a new entity."
         }

--- a/app/server/commands/wikipedia_command.py
+++ b/app/server/commands/wikipedia_command.py
@@ -57,4 +57,7 @@ class WikipediaCommand(Commands):
         return embed
 
     def get_help(self):
-        return self.parameter_error
+        return {
+            "brief": "Access Wikipedia information",
+            "help": "This command allows you to search or get a summary of a topic from Wikipedia."
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ dataclasses-json==0.6.4
 dill==0.3.8
 discord.py==2.3.2
 exceptiongroup==1.2.0
+flake8==7.0.0
 frozenlist==1.4.1
 greenlet==3.0.3
 idna==3.6
@@ -36,6 +37,7 @@ pycodestyle==2.11.1
 pydantic==2.7.1
 pydantic_core==2.18.2
 pyflakes==3.2.0
+pylint==3.1.0
 pytest==8.1.1
 python-dotenv==1.0.1
 PyYAML==6.0.1


### PR DESCRIPTION
There was a problem how the help information was displayed in `wikipedia_command` because an issue with `get_help` and the return string.